### PR TITLE
How about using absolute paths in css `url()` function?

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,14 +1,21 @@
 module.exports = {
-  "stories": ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-  "addons": ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-interactions", "@storybook/addon-mdx-gfm"],
-  "framework": {
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
+    "@storybook/addon-links",
+    "@storybook/addon-essentials",
+    "@storybook/addon-interactions",
+    "@storybook/addon-mdx-gfm",
+  ],
+  framework: {
     name: "@storybook/react-vite",
-    options: {}
+    options: {},
   },
-  "features": {
-    "storyStoreV7": true
+  features: {
+    storyStoreV7: true,
   },
   docs: {
-    autodocs: true
-  }
+    autodocs: true,
+  },
+  // https://storybook.js.org/docs/react/api/main-config-static-dirs#page-top
+  staticDirs: ["../public"],
 };

--- a/themes/style.scss
+++ b/themes/style.scss
@@ -1,4 +1,4 @@
 .has-background {
-    background-image: url('./images/vite.svg');
-    height:500px;
+  background-image: url("/images/vite.svg");
+  height: 500px;
 }


### PR DESCRIPTION
Since Vite already provides `pubilcDir` mechanism, and you can achieve the same thing in Storybook via [staticDir](https://storybook.js.org/docs/react/api/main-config-static-dirs#page-top), I think it'd be a bit easier to reason about css urls with absolute paths rather than trying to backtrack the relative urls from each compile/build output (e.g., `dist` and `storybook-static`).

It seems to work from my end, but do check this PR out to see if it solves your use case!

